### PR TITLE
Adds URL validation on Place

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -1,3 +1,5 @@
+require 'url_validator'
+
 class Place < ActiveRecord::Base
   RESERVED_TAGS = ["eat it", "drink it", "do it"]
   WALKING_DISTANCE_MINUTES = 15
@@ -6,6 +8,7 @@ class Place < ActiveRecord::Base
   acts_as_taggable
 
   validates :name, :address, presence: true
+  validates :url, url: true, allow_nil: true
 
   scope :walking_distance, -> { where("walking_time_in_minutes <= ?", WALKING_DISTANCE_MINUTES) }
   scope :taxi_distance, -> { where("walking_time_in_minutes > ?", WALKING_DISTANCE_MINUTES) }

--- a/lib/url_validator.rb
+++ b/lib/url_validator.rb
@@ -1,0 +1,17 @@
+require 'uri'
+
+class UrlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return true if options[:allow_nil] && value.nil?
+    record.errors.add attribute, "must be a URL starting with http" unless valid_url?(value)
+  end
+
+  private
+
+  def valid_url?(url)
+    uri = URI.parse(url)
+    uri.kind_of?(URI::HTTP)
+  rescue URI::InvalidURIError
+    false
+  end
+end

--- a/test/fixtures/places.yml
+++ b/test/fixtures/places.yml
@@ -2,7 +2,7 @@
 
 one:
   name: MyString
-  url: MyString
+  url: http://shopify.com
   phone_number: MyString
   address: MyString
   description: MyText
@@ -10,7 +10,7 @@ one:
 
 two:
   name: MyString
-  url: MyString
+  url: http://shopify.com
   phone_number: MyString
   address: MyString
   description: MyText

--- a/test/models/place_test.rb
+++ b/test/models/place_test.rb
@@ -1,7 +1,23 @@
 require 'test_helper'
 
 class PlaceTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "Place URLs should start with http" do
+    bad_url = "javascript:alert(1)"
+    place = Place.new(url: bad_url)
+
+    refute place.valid?
+    refute place.errors[:url].empty?
+
+    good_url = "http://shopify.com"
+    place = Place.new(url: good_url)
+
+    assert place.errors[:url].empty?
+  end
+
+  test "Place URLs can be nil" do
+    place = Place.new(url: nil)
+    place.valid?
+
+    assert place.errors[:url].empty?
+  end
 end


### PR DESCRIPTION
Adds URL validation to `Place` to prevent XSS exploits when entering malicious data in the URL field.

@clayton-shopify for review