### PR TITLE
Fix Shopify address so Google maps work.

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -3,7 +3,7 @@ require 'url_validator'
 class Place < ActiveRecord::Base
   RESERVED_TAGS = ["eat it", "drink it", "do it"]
   WALKING_DISTANCE_MINUTES = 15
-  SHOPIFY_OTTAWA_ADDRESS = "150 Elgin Street, Ottawa, Ontario, Canada"
+  SHOPIFY_OTTAWA_ADDRESS = "150 Elgin Street, Ottawa, ON, K2P1L4"
 
   acts_as_taggable
 


### PR DESCRIPTION
For review @edward 

Right now all the Google maps show a piece of Kanata because Google puts the Shopify pin at 150 Elgin St. in Almonte:

![screen shot 2015-08-25 at 2 40 42 pm](https://cloud.githubusercontent.com/assets/11052374/9475846/6275cc56-4b37-11e5-8ff9-940d3edfed59.png)

Adding the postal code to our address fixes that:

![screen shot 2015-08-25 at 2 43 48 pm](https://cloud.githubusercontent.com/assets/11052374/9475934/bd3c0b50-4b37-11e5-899d-8b58b0dee346.png)
